### PR TITLE
Missing 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ![GitHub Repo stars](https://img.shields.io/github/stars/crjeder/hx711_spi?style=plastic)
 ![Crates.io](https://img.shields.io/crates/d/hx711_spi?style=plastic)
 
-This is a platform agnostic driver to interface with the HX711 load cell IC. It uses SPI instad of bit banging.
+This is a platform agnostic driver to interface with the HX711 load cell IC. It uses SPI instead of bit banging.
 This driver is built using [`embedded-hal`][2] traits.
 
 ## Why did I write another HX711 driver?
@@ -59,6 +59,23 @@ fn main() -> Result<(), Error>
 }
 
 ```
+
+An example stm32f103 (blue pill) initialization (note mode 1).
+
+``` rust
+    let hx711_spi_pins = (
+        gpiob.pb13.into_alternate_push_pull(&mut gpiob.crh),
+        gpiob.pb14.into_floating_input(&mut gpiob.crh),
+        gpiob.pb15.into_alternate_push_pull(&mut gpiob.crh),
+    );
+    let hx711_spi = spi::Spi::spi2(device.SPI2, hx711_spi_pins, spi::MODE_1, 1.MHz(), clocks);
+    let tim_delay = device.TIM1.delay::<1_000_000>(&clocks);
+    let mut hx711_sensor = Hx711::new(hx711_spi, tim_delay);
+    hx711_sensor.reset().unwrap();
+    hx711_sensor.set_mode(hx711_spi::Mode::ChAGain128).unwrap(); // x128 works up to +-20mV
+```
+
+
 ## Feedback
 All kind of feedback is welcome. If you have questions or problems, please post them on the issue tracker
 This is literally the first code I ever wrote in rust. I am still learning. So please be patient, it might take me some time to fix a bug. I may have to break my knowledge sound-barrier.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,8 +146,8 @@ where
         // the read has the same length as the write.
         // MOSI provides clock to the HX711's shift register (binary 1010...)
         // clock is 10 the buffer needs to be double the size of the 4 bytes we want to read
-        let mut buffer: [u8; 8] = [0b10101010, 0b10101010, 0b10101010, 0b10101010,
-                                   0b10101010, 0b10101010, self.mode as u8, 0];
+        let mut buffer: [u8; 7] = [0b10101010, 0b10101010, 0b10101010, 0b10101010,
+                                   0b10101010, 0b10101010, self.mode as u8];
 
         self.spi.transfer(&mut buffer)?;
         // value should be in range 0x800000 - 0x7fffff according to datasheet
@@ -238,7 +238,7 @@ where
 {}
 
 #[bitmatch]
-fn decode_output(buffer: &[u8;8]) -> i32
+fn decode_output(buffer: &[u8;7]) -> i32
 {
     // buffer contains the 2's complement of the reading with every bit doubled
     // since the first byte is the most significant it's big endian

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,11 +64,11 @@ use bitmatch::bitmatch;
 pub enum Mode{
     // bits have to be converted for correct transfer 1 -> 10, 0 -> 00
     /// Convet channel A with a gain factor of 128
-    ChAGain128 = 0b1000000,
+    ChAGain128 = 0b10000000,
     /// Convert channel B with a gain factor of 64
-    ChBGain32 = 0b10100000,
+    ChBGain32 =  0b10100000,
     /// Convert channel A with a gain factor of 32
-    ChAGain64 = 0b10101000
+    ChAGain64 =  0b10101000
     // there is a typo in the official datasheet: in Fig.2 it says channel B instead of A
 }
 


### PR DESCRIPTION
* add a missing 0 in the "mode" enum
* update README, mention SPI mode 1
* remove extra byte transfer