### PR TITLE
Fix for stable Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ No scales functions (like tare weight and calibration) are implemented because I
   - [X] Power down (functions exist just for compatibility. Implementation is not possible with SPI)
   - [X] Reset
   - [X] `[no_std]`
-  - [ ] make it re-entrant / thread safe
+  - [X] make it re-entrant / thread safe
 
 ## Usage
 Use an embedded-hal implementation (e. g. rppal) to get SPI. HX711 does not use CS and SCLK. Make sure that it

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -1,5 +1,8 @@
 // embedded_hal implementation
-use rppal::{spi::{Spi, Bus, SlaveSelect, Mode, Error},hal::Delay};
+use rppal::{
+    hal::Delay,
+    spi::{Bus, Error, Mode, SlaveSelect, Spi},
+};
 
 use hx711_spi::Hx711;
 use nb::block;
@@ -10,9 +13,9 @@ fn main() -> Result<(), Error>
     let spi = Spi::new(Bus::Spi0, SlaveSelect::Ss0, 1_000_000, Mode::Mode0)?;
     let mut hx711 = Hx711::new(spi, Delay::new());
 
-	hx711.reset()?;
+    hx711.reset()?;
     let v = block!(hx711.read())?;
-	println!("value = {}", v);
+    println!("value = {}", v);
 
     Ok(())
 }

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -1,8 +1,6 @@
 // embedded_hal implementation
-use rppal::{
-    hal::Delay,
-    spi::{Bus, Error, Mode, SlaveSelect, Spi},
-};
+use rppal::hal::Delay;
+use rppal::spi::{Bus, Error, Mode, SlaveSelect, Spi};
 
 use hx711_spi::Hx711;
 use nb::block;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,10 +45,8 @@
 //!
 
 #![no_std]
-#![feature(negative_impls)]
 
 use bitmatch::bitmatch; // use bitmatch to decode the result
-use core::marker::Sync;
 use core::unimplemented;
 use embedded_hal as hal;
 use hal::blocking::delay::DelayMs;
@@ -96,14 +94,6 @@ where
     /// let dev = Spi::new(bus, SlaveSelect::Ss0, 1_000_000, Mode::Mode0)?;
     ///```
     /// D is an embedded_hal implementation of DelayMs.
-    ///
-    /// # Safety
-    ///
-    /// It's unsafe to use Hx711 in multi-threading environments since a call to the read and reset
-    /// functions would result in undefined behaviour if the previous call has not finished first.
-    ///
-    /// Changing the mode is safe since it is applied on the next read and takes effect on the
-    /// second read operation.
     pub fn new(spi: SPI, delay: D) -> Self
     {
         Hx711 {
@@ -225,17 +215,6 @@ where
         // of binary '1' which would block the process
         unimplemented!("power_down is not possible with this driver implementation");
     }
-}
-
-// it's not safe to use SPI bus from different treads and therefore the Hx711 driver is not
-// tread-safe either
-// this should not be necessary since the actual implementations for SPI should correctly implement Sync
-// but I don't want Sync to be auto implemented
-impl<SPI, E, T> !Sync for Hx711<SPI, T>
-where
-    SPI: spi::Transfer<u8, Error = E> + spi::Write<u8, Error = E>,
-    T: DelayMs<u16>,
-{
 }
 
 #[bitmatch]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! HX711 embedded-hal SPI driver crate
 //!
-//! This is a platform agnostic driver to interface with the HX711 load cell IC. It uses SPI instad of bit banging.
+//! This is a platform agnostic driver to interface with the HX711 load cell IC. It uses SPI instead of bit banging.
 //! This driver [no_std] is built using [`embedded-hal`][2] traits.
 //!
 //!
@@ -24,9 +24,9 @@
 //!     let spi = Spi::new(Bus::Spi0, SlaveSelect::Ss0, 1_000_000, Mode::Mode0)?;
 //!     let mut hx711 = Hx711::new(spi, Delay::new());
 //!
-//! 	hx711.reset()?;
+//!     hx711.reset()?;
 //!     let v = block!(hx711.read())?;
-//! 	println!("value = {}", v);
+//!     println!("value = {}", v);
 //!
 //!     Ok(())
 //! }
@@ -47,6 +47,7 @@
 #![no_std]
 #![feature(negative_impls)]
 
+use bitmatch::bitmatch; // use bitmatch to decode the result
 use core::marker::Sync;
 use core::unimplemented;
 use embedded_hal as hal;
@@ -54,17 +55,14 @@ use hal::blocking::delay::DelayMs;
 use hal::blocking::spi;
 use nb::{self, block};
 
-// use bitmach to decode the result
-use bitmatch::bitmatch;
-
-/// The HX711 has two chanels: `A` for the load cell and `B` for AD conversion of other signals.
+/// The HX711 has two channels: `A` for the load cell and `B` for AD conversion of other signals.
 /// Channel `A` supports gains of 128 (default) and 64, `B` has a fixed gain of 32.
 #[derive(Copy, Clone, Debug)]
 #[repr(u8)]
 pub enum Mode
 {
     // bits have to be converted for correct transfer 1 -> 10, 0 -> 00
-    /// Convet channel A with a gain factor of 128
+    /// Convert channel A with a gain factor of 128
     ChAGain128 = 0b10000000,
     /// Convert channel B with a gain factor of 64
     ChBGain32 = 0b10100000,
@@ -75,15 +73,12 @@ pub enum Mode
 /// Represents an instance of a HX711 device
 #[derive(Debug)]
 pub struct Hx711<SPI, D>
-//where
-//    SPI: spi::Transfer<u8, Error=E> + spi::Write<u8, Error=E>,
-//    T: DelayUs<u16> + DelayMs<u16>
 {
     // SPI specific
     spi: SPI,
     // device specific
     mode: Mode,
-    // timeer for delay
+    // timer for delay
     delay: D,
 }
 
@@ -118,9 +113,10 @@ where
         }
     }
 
-    /// reads a value from the HX711 and retrurns it
+    /// reads a value from the HX711 and returns it
     /// # Examples
     /// ```rust
+    /// # use nb::block;
     /// let v = block!(hx711.read())?;
     /// ```
     /// # Errors


### PR DESCRIPTION
Hi!

Thanks for writing this crate! It got me up and running with my HX711 based scale on a slow and ancient Raspberry Pi Zero. So far all readings have been very stable and correct.

I generally try to stick with the stable Rust compiler, so I noticed this crate uses an unstable feature (`#![feature(negative_impls)]`) which requires the nightly compiler. 

I read through the code and understand you added the `!Sync` negative trait bound to prevent sharing of `Hx711` between threads.

However, as far as I can tell, this is not required with the code in it's current state:
- All functions require a `&mut self`, which Rust guarantees is singular. (Thus preventing any reentrancy issues)
- Because the code uses blocking SPI, no transfers persist between calls.
- If the SPI HAL implementation is not Send+Sync safe, it will propagate correctly to the `Hx711` struct
- No `unsafe` code exists in the library, which usually makes it very hard to not be Send+Sync safe

This pull request removes the `!Sync` bound, reformats the code using `cargo +nightly fmt`, and has some minor cleanups and typo fixes.

Please let me know if you have any questions or want to discuss anything 😄

Cheers!

--James