### PR TITLE
Update deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -95,7 +95,7 @@ copyleft = "warn"
 # * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
 # * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
 # * neither - This predicate is ignored and the default lint level is used
-allow-osi-fsf-free = "both"
+allow-osi-fsf-free = "either"
 # Lint level used when no other predicates are matched
 # 1. License isn't in the allow or deny lists
 # 2. License isn't copyleft
@@ -112,6 +112,8 @@ exceptions = [
     # Each entry is the crate and version constraint, and its specific allow
     # list
     #{ allow = ["Zlib"], name = "adler32", version = "*" },
+    # needed since syn included unicode-ident
+    exceptions = [{ name = "unicode-ident", allow = ["Unicode-DFS-2016"] }]
 ]
 
 # Some crates don't have (easily) machine readable licensing information,


### PR DESCRIPTION
Added a license exeption which is needed since syn included unicode-ident.  exceptions = [{ name = "unicode-ident", allow = ["Unicode-DFS-2016"] }]