### PR TITLE
0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2023-02-26
+### Changed
+- introduce the feature ```invert-sdo```
+- remove the delay parameter **breaking change!**
+
 ## [0.4.2] - 2023-02-25
 Fixed a bug in the detectoin of hx711 ready state
 Refacuring the code for better maintainability

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ embedded-hal = "0.2.4"
 bitmatch = "0.1.1"
 nb = "1.0"
 
+
+[features]
+invert-sdo = []
+
 [dev-dependencies]
 test-case = "3"
 embedded-hal-mock = "0.9.0"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 
 This is a platform agnostic driver to interface with the HX711 load cell IC. It uses SPI instead of bit banging.
 This `[no_std]` driver is built using [`embedded-hal`][2] traits.
+It is developed on Raspberry PI and reported to work on STM32 and ESP32.
 It is recommended to always use [cargo-crev](https://github.com/crev-dev/cargo-crev)
 to verify the trustworthiness of each of your dependencies, including this one.
 
@@ -55,7 +56,7 @@ use nb::block;
 fn main() -> Result<(), Error>
 {
     let spi = Spi::new(Bus::Spi0, SlaveSelect::Ss0, 1_000_000, Mode::Mode0)?;
-    let mut hx711 = Hx711::new(spi, Delay::new());
+    let mut hx711 = Hx711::new(spi);
 
 	  hx711.reset()?;
     let v = block!(hx711.read())?;
@@ -85,8 +86,7 @@ An example stm32f103 (blue pill) initialization (note mode 1).
         gpiob.pb15.into_alternate_push_pull(&mut gpiob.crh),
     );
     let hx711_spi = spi::Spi::spi2(device.SPI2, hx711_spi_pins, spi::MODE_1, 1.mhz(), clocks);
-    let tim_delay = device.TIM1.delay::<1_000_000>(&clocks);
-    let mut hx711_sensor = Hx711::new(hx711_spi, tim_delay);
+    let mut hx711_sensor = Hx711::new(hx711_spi);
     hx711_sensor.reset().unwrap();
     hx711_sensor.set_mode(hx711_spi::Mode::ChAGain128).unwrap(); // x128 works up to +-20mV
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Connect the SDO to the PD_SCK and SDI to DOUT of the HX711. SPI clock frequency
 has to be between 20 kHz and 5 MHz.
 Since the SPI clock is not used, SPI mode 0 or mode 1 should work. You need
 test which one gives the best results for you.
-The library assumes that SDO signal is idle low. If this is not the case you have to use extra hardware to pull it low. In this case you should use the [invert-sdo] feature to send the correct signals to the hx711.
+The library assumes that SDO signal is idle low. If this is not the case you have to use extra hardware to pull it low. In this case you should use the ```[invert-sdo]``` feature to send the correct signals to the hx711.
 
 No scales functions (like tare weight and calibration) are implemented because I feel that's not part of a device driver.
 Power down functions exist just for compatibility. Implementation is not possible with this (ab-) use of SPI since the CPU / MPU would need to constantly send on the bus to power donwn the HX711. This would totally defy the purpose.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Connect the SDO to the PD_SCK and SDI to DOUT of the HX711. SPI clock frequency
 has to be between 20 kHz and 5 MHz.
 Since the SPI clock is not used, SPI mode 0 or mode 1 should work. You need
 test which one gives the best results for you.
+The library assumes that SDO signal is idle low. If this is not the case you have to use extra hardware to pull it low. In this case you should use the [invert-sdo] feature to send the correct signals to the hx711.
 
 No scales functions (like tare weight and calibration) are implemented because I feel that's not part of a device driver.
 Power down functions exist just for compatibility. Implementation is not possible with this (ab-) use of SPI since the CPU / MPU would need to constantly send on the bus to power donwn the HX711. This would totally defy the purpose.

--- a/examples/raspberry.rs
+++ b/examples/raspberry.rs
@@ -7,7 +7,7 @@ use nb::block;
 // minimal example
 fn main() -> Result<(), Error> {
     let spi = Spi::new(Bus::Spi0, SlaveSelect::Ss0, 1_000_000, Mode::Mode1)?;
-    let mut hx711 = Hx711::new(spi));
+    let mut hx711 = Hx711::new(spi);
 
     hx711.reset()?;
     let v = block!(hx711.read())?;

--- a/examples/raspberry.rs
+++ b/examples/raspberry.rs
@@ -1,5 +1,4 @@
 // embedded_hal implementation
-use rppal::hal::Delay;
 use rppal::spi::{Bus, Error, Mode, SlaveSelect, Spi};
 
 use hx711_spi::Hx711;
@@ -8,7 +7,7 @@ use nb::block;
 // minimal example
 fn main() -> Result<(), Error> {
     let spi = Spi::new(Bus::Spi0, SlaveSelect::Ss0, 1_000_000, Mode::Mode1)?;
-    let mut hx711 = Hx711::new(spi, Delay::new());
+    let mut hx711 = Hx711::new(spi));
 
     hx711.reset()?;
     let v = block!(hx711.read())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,19 +12,39 @@ use nb::{self, block};
 // for the ```invert-sdo``` feature
 
 // patterns for mode
+#[cfg(not(feature = "invert-sdo"))]
 const GAIN128: u8 = 0b1000_0000;
+#[cfg(feature = "invert-sdo")]
+const GAIN128: u8 = 0b0111_1111;
+
+#[cfg(not(feature = "invert-sdo"))]
 const GAIN32: u8 = 0b1010_0000;
+#[cfg(feature = "invert-sdo")]
+const GAIN32: u8 = 0b0101_1111;
+
+#[cfg(not(feature = "invert-sdo"))]
 const GAIN64: u8 = 0b1010_1000;
+#[cfg(feature = "invert-sdo")]
+const GAIN32: u8 = 0b0101_0111;
 
 // SDO provides clock to the HX711's shift register (binary 1010...)
 // one clock cycle is '10'. The buffer needs to be double the size of the 4 bytes we want to read
+#[cfg(not(feature = "invert-sdo"))]
 const CLOCK: u8 = 0b10101010;
+#[cfg(feature = "invert-sdo")]
+const CLOCK: u8 = 0b0101010;
 
 // Signal to send to the HX711 when checking for data ready to be read.
+#[cfg(not(feature = "invert-sdo"))]
 const SIGNAL_LOW: u8 = 0x0;
+#[cfg(feature = "invert-sdo")]
+const SIGNAL_LOW: u8 = 0xFF;
 
 // reset signal
+#[cfg(not(feature = "invert-sdo"))]
 const RESET_SIGNAL: [u8; 301] = [0xFF; 301];
+#[cfg(feature = "invert-sdo")]
+const RESET_SIGNAL: [u8; 301] = [0x00; 301];
 
 // End bit pattern definitions
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,28 @@
 use bitmatch::bitmatch;
 use core::unimplemented;
 use embedded_hal as hal;
-use hal::blocking::delay::DelayMs;
 use hal::blocking::spi;
 use nb::{self, block};
+
+// Bit pattern definitions for the communication with the hx711. All have to be bitwise negate
+// for the ```invert-sdo``` feature
+
+// patterns for mode
+const GAIN128: u8 = 0b1000_0000;
+const GAIN32: u8 = 0b1010_0000;
+const GAIN64: u8 = 0b1010_1000;
+
+// SDO provides clock to the HX711's shift register (binary 1010...)
+// one clock cycle is '10'. The buffer needs to be double the size of the 4 bytes we want to read
+const CLOCK: u8 = 0b10101010;
+
+// Signal to send to the HX711 when checking for data ready to be read.
+const SIGNAL_LOW: u8 = 0x0;
+
+// reset signal
+const RESET_SIGNAL: [u8; 301] = [0xFF; 301];
+
+// End bit pattern definitions
 
 /// The HX711 has two channels: `A` for the load cell and `B` for AD conversion of other signals.
 /// Channel `A` supports gains of 128 (default) and 64, `B` has a fixed gain of 32.
@@ -16,39 +35,35 @@ use nb::{self, block};
 pub enum Mode {
     // bits have to be converted for correct transfer 1 -> 10, 0 -> 00
     /// Convert channel A with a gain factor of 128
-    ChAGain128 = 0b1000_0000,
+    ChAGain128 = GAIN128,
     /// Convert channel B with a gain factor of 32
-    ChBGain32 = 0b1010_0000,
+    ChBGain32 = GAIN32,
     /// Convert channel A with a gain factor of 64
-    ChAGain64 = 0b1010_1000, // there is a typo in the official datasheet: in Fig.2 it says channel B instead of A
+    ChAGain64 = GAIN64, // there is a typo in the official datasheet: in Fig.2 it says channel B instead of A
 }
 
 /// Represents an instance of a HX711 device
 #[derive(Debug)]
-pub struct Hx711<SPI, D> {
+pub struct Hx711<SPI> {
     // SPI specific
     spi: SPI,
     // device specific
     mode: Mode,
-    // timer for delay
-    delay: D,
 }
 
-impl<SPI, E, D> Hx711<SPI, D>
+impl<SPI, E> Hx711<SPI>
 where
     SPI: spi::Transfer<u8, Error = E> + spi::Write<u8, Error = E>,
-    D: DelayMs<u16>,
 {
     /// opens a connection to a HX711 on a specified SPI.
     ///
     /// The datasheet specifies PD_SCK high time and PD_SCK low time to be in the 0.2 to 50 us range,
     /// therefore bus speed has to be between 5 MHz and 20 kHz. 1 MHz seems to be a good choice.
     /// D is an embedded_hal implementation of DelayMs.
-    pub fn new(spi: SPI, delay: D) -> Self {
+    pub fn new(spi: SPI) -> Self {
         Hx711 {
             spi,
             mode: Mode::ChAGain128,
-            delay,
         }
     }
 
@@ -60,7 +75,7 @@ where
         // When output data is not ready for retrieval, digital output pin DOUT is high.
         // Serial clock input PD_SCK should be low. When DOUT goes
         // to low, it indicates data is ready for retrieval.
-        let mut txrx: [u8; 1] = [0];
+        let mut txrx: [u8; 1] = [SIGNAL_LOW];
 
         self.spi.transfer(&mut txrx)?;
 
@@ -70,10 +85,7 @@ where
         }
 
         // the read has the same length as the write.
-        // SDO provides clock to the HX711's shift register (binary 1010...)
-        // one clock cycle is '10'. The buffer needs to be double the size of the 4 bytes we want to read
-        const CLOCK: u8 = 0b10101010;
-
+        
         let mut buffer: [u8; 7] = [CLOCK, CLOCK, CLOCK, CLOCK, CLOCK, CLOCK, self.mode as u8];
 
         self.spi.transfer(&mut buffer)?;
@@ -100,7 +112,7 @@ where
         // max SPI clock frequency should be 5 MHz to satisfy the 0.2 us limit for the pulse length
         // we have to output more than 300 bytes to keep the line for at least 60 us high.
 
-        let buffer: [u8; 301] = [0xFF; 301];
+        let buffer: [u8; 301] = RESET_SIGNAL;
 
         self.spi.write(&buffer)?;
         self.mode = Mode::ChAGain128; // this is the default mode after reset

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,14 +25,14 @@ const GAIN32: u8 = 0b0101_1111;
 #[cfg(not(feature = "invert-sdo"))]
 const GAIN64: u8 = 0b1010_1000;
 #[cfg(feature = "invert-sdo")]
-const GAIN32: u8 = 0b0101_0111;
+const GAIN64: u8 = 0b0101_0111;
 
 // SDO provides clock to the HX711's shift register (binary 1010...)
 // one clock cycle is '10'. The buffer needs to be double the size of the 4 bytes we want to read
 #[cfg(not(feature = "invert-sdo"))]
 const CLOCK: u8 = 0b10101010;
 #[cfg(feature = "invert-sdo")]
-const CLOCK: u8 = 0b0101010;
+const CLOCK: u8 = 0b01010101;
 
 // Signal to send to the HX711 when checking for data ready to be read.
 #[cfg(not(feature = "invert-sdo"))]


### PR DESCRIPTION
This release introduces the `invert-sdo` feature and breaks tha API by removing the need for the delay parameter.